### PR TITLE
Enable `IPython Clusters` widget in notebook

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: c46cd3bad50bbe12106257241d671ce6edb3faca2ced54ed001b8f1d579720f0
 
 build:
-  number: 1
+  number: 2
   script:
     - pip install --no-deps .
     - jupyter nbextension install --sys-prefix --py ipyparallel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,9 @@ source:
 
 build:
   number: 1
-  script: pip install --no-deps .
+  script:
+    - pip install --no-deps .
+    - jupyter nbextension install --sys-prefix --py ipyparallel
 
 requirements:
   build:
@@ -26,6 +28,12 @@ requirements:
     - jupyter_client
     - ipykernel
     - tornado >=4
+    # To install the notebook extension.
+    #
+    # We don't require this to install/use
+    # ipyparallel though. So we don't make
+    # it a run-time requirement.
+    - notebook
 
   run:
     - python

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,0 +1,14 @@
+:: Disable command output.
+@echo off
+
+:: Check to make sure we can install the ipyparallel widget.
+"%PREFIX%\Scripts\jupyter" serverextension --version > NUL 2>&1 && if errorlevel 1 goto End
+"%PREFIX%\Scripts\jupyter" nbextension --version > NUL 2>&1 && if errorlevel 1 goto End
+
+:: Install the ipyparallel widget.
+"%PREFIX%\Scripts\jupyter" serverextension enable --sys-prefix --py ipyparallel > NUL 2>&1 && if errorlevel 1 exit 1
+"%PREFIX%\Scripts\jupyter" nbextension install --sys-prefix --py ipyparallel > NUL 2>&1 && if errorlevel 1 exit 1
+"%PREFIX%\Scripts\jupyter" nbextension enable --sys-prefix --py ipyparallel > NUL 2>&1 && if errorlevel 1 exit 1
+
+:End
+exit 0

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -7,7 +7,6 @@
 
 :: Install the ipyparallel widget.
 "%PREFIX%\Scripts\jupyter" serverextension enable --sys-prefix --py ipyparallel > NUL 2>&1 && if errorlevel 1 exit 1
-"%PREFIX%\Scripts\jupyter" nbextension install --sys-prefix --py ipyparallel > NUL 2>&1 && if errorlevel 1 exit 1
 "%PREFIX%\Scripts\jupyter" nbextension enable --sys-prefix --py ipyparallel > NUL 2>&1 && if errorlevel 1 exit 1
 
 :End

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -4,5 +4,4 @@
 
 # Install the ipyparallel widget.
 "${PREFIX}/bin/jupyter" serverextension enable --sys-prefix --py ipyparallel > /dev/null 2>&1
-"${PREFIX}/bin/jupyter" nbextension install --sys-prefix --py ipyparallel > /dev/null 2>&1
 "${PREFIX}/bin/jupyter" nbextension enable --sys-prefix --py ipyparallel > /dev/null 2>&1

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,0 +1,8 @@
+# Check to make sure we can install the ipyparallel widget.
+("${PREFIX}/bin/jupyter" serverextension --version > /dev/null 2>&1) || exit 0
+("${PREFIX}/bin/jupyter" nbextension --version > /dev/null 2>&1) || exit 0
+
+# Install the ipyparallel widget.
+"${PREFIX}/bin/jupyter" serverextension enable --sys-prefix --py ipyparallel > /dev/null 2>&1
+"${PREFIX}/bin/jupyter" nbextension install --sys-prefix --py ipyparallel > /dev/null 2>&1
+"${PREFIX}/bin/jupyter" nbextension enable --sys-prefix --py ipyparallel > /dev/null 2>&1

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -7,7 +7,6 @@
 
 :: Install the ipyparallel widget.
 "%PREFIX%\Scripts\jupyter" nbextension disable --sys-prefix --py ipyparallel > NUL 2>&1 && if errorlevel 1 exit 1
-"%PREFIX%\Scripts\jupyter" nbextension uninstall --sys-prefix --py ipyparallel > NUL 2>&1 && if errorlevel 1 exit 1
 "%PREFIX%\Scripts\jupyter" serverextension disable --sys-prefix --py ipyparallel > NUL 2>&1 && if errorlevel 1 exit 1
 
 :End

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -1,0 +1,14 @@
+:: Disable command output.
+@echo off
+
+:: Check to make sure we can install the ipyparallel widget.
+"%PREFIX%\Scripts\jupyter" serverextension --version > NUL 2>&1 && if errorlevel 1 goto End
+"%PREFIX%\Scripts\jupyter" nbextension --version > NUL 2>&1 && if errorlevel 1 goto End
+
+:: Install the ipyparallel widget.
+"%PREFIX%\Scripts\jupyter" nbextension disable --sys-prefix --py ipyparallel > NUL 2>&1 && if errorlevel 1 exit 1
+"%PREFIX%\Scripts\jupyter" nbextension uninstall --sys-prefix --py ipyparallel > NUL 2>&1 && if errorlevel 1 exit 1
+"%PREFIX%\Scripts\jupyter" serverextension disable --sys-prefix --py ipyparallel > NUL 2>&1 && if errorlevel 1 exit 1
+
+:End
+exit 0

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -4,5 +4,4 @@
 
 # Install the ipyparallel widget.
 "${PREFIX}/bin/jupyter" nbextension disable --sys-prefix --py ipyparallel > /dev/null 2>&1
-"${PREFIX}/bin/jupyter" nbextension uninstall --sys-prefix --py ipyparallel > /dev/null 2>&1
 "${PREFIX}/bin/jupyter" serverextension disable --sys-prefix --py ipyparallel > /dev/null 2>&1

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,0 +1,8 @@
+# Check to make sure we can install the ipyparallel widget.
+("${PREFIX}/bin/jupyter" serverextension --version > /dev/null 2>&1) || exit 0
+("${PREFIX}/bin/jupyter" nbextension --version > /dev/null 2>&1) || exit 0
+
+# Install the ipyparallel widget.
+"${PREFIX}/bin/jupyter" nbextension disable --sys-prefix --py ipyparallel > /dev/null 2>&1
+"${PREFIX}/bin/jupyter" nbextension uninstall --sys-prefix --py ipyparallel > /dev/null 2>&1
+"${PREFIX}/bin/jupyter" serverextension disable --sys-prefix --py ipyparallel > /dev/null 2>&1


### PR DESCRIPTION
Fixes https://github.com/conda-forge/ipyparallel-feedstock/issues/5

This adds some link scripts to try enabling and disabling the `IPython Clusters` widget in the notebook. As the notebook may not be installed, they also check if the widget can be installed. If the prerequisites are not available, it exits cleanly. However, if the prerequisites are available and it fails to install, then the install gives an exit code and reverts the installation. Followed these [instructions](http://ipyparallel.readthedocs.io/en/latest/changelog.html#nbextensions) to do the install.

cc @minrk
