### PR TITLE
Require `pip`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,12 +10,13 @@ source:
   sha256: c46cd3bad50bbe12106257241d671ce6edb3faca2ced54ed001b8f1d579720f0
 
 build:
-  number: 0
+  number: 1
   script: pip install --no-deps .
 
 requirements:
   build:
     - python
+    - pip
     - futures               # [py<32]
     - decorator
     - tornado >=4


### PR DESCRIPTION
As we are using `pip` to install, add it as an explicit requirement. This will be necessary in the near term as we are no longer allowing `pip`, `setuptools`, and `wheel` to be installed with `python`. One will need to explicitly add them if they are needed. This has already happened at staged-recipes and some feedstocks. We should prepare this one for that change.
