### PR TITLE
robustify post-link scripts

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: d99e760f1a136b1c402755a4ab51a8d7cb87c892cccadf641948a5e886c8a455
 
 build:
-  number: 0
+  number: 1
   script:
     - pip install --no-deps .
     - jupyter nbextension install --sys-prefix --py ipyparallel

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -2,12 +2,12 @@
 @echo off
 
 :: Check to make sure we can install the ipyparallel widget.
-"%PREFIX%\Scripts\jupyter" serverextension --version > NUL 2>&1 && if errorlevel 1 goto End
-"%PREFIX%\Scripts\jupyter" nbextension --version > NUL 2>&1 && if errorlevel 1 goto End
+"%PREFIX%\Scripts\jupyter-serverextension" --version > NUL 2>&1 && if errorlevel 1 goto End
+"%PREFIX%\Scripts\jupyter-nbextension" --version > NUL 2>&1 && if errorlevel 1 goto End
 
 :: Install the ipyparallel widget.
-"%PREFIX%\Scripts\jupyter" serverextension enable --sys-prefix --py ipyparallel > NUL 2>&1 && if errorlevel 1 exit 1
-"%PREFIX%\Scripts\jupyter" nbextension enable --sys-prefix --py ipyparallel > NUL 2>&1 && if errorlevel 1 exit 1
+"%PREFIX%\Scripts\jupyter-serverextension" enable --sys-prefix --py ipyparallel --Application.log_level=ERROR > NUL && if errorlevel 1 exit 1
+"%PREFIX%\Scripts\jupyter-nbextension" enable --sys-prefix --py ipyparallel --Application.log_level=ERROR > NUL && if errorlevel 1 exit 1
 
 :End
 exit 0

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,7 +1,7 @@
 # Check to make sure we can install the ipyparallel widget.
-("${PREFIX}/bin/jupyter" serverextension --version > /dev/null 2>&1) || exit 0
-("${PREFIX}/bin/jupyter" nbextension --version > /dev/null 2>&1) || exit 0
+("${PREFIX}/bin/jupyter-serverextension" --version > /dev/null 2>&1) || exit 0
+("${PREFIX}/bin/jupyter-nbextension" --version > /dev/null 2>&1) || exit 0
 
 # Install the ipyparallel widget.
-"${PREFIX}/bin/jupyter" serverextension enable --sys-prefix --py ipyparallel > /dev/null 2>&1
-"${PREFIX}/bin/jupyter" nbextension enable --sys-prefix --py ipyparallel > /dev/null 2>&1
+"${PREFIX}/bin/jupyter-serverextension" enable --sys-prefix --py ipyparallel --Application.log_level=ERROR > /dev/null
+"${PREFIX}/bin/jupyter-nbextension" enable --sys-prefix --py ipyparallel --Application.log_level=ERROR > /dev/null

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -2,12 +2,12 @@
 @echo off
 
 :: Check to make sure we can install the ipyparallel widget.
-"%PREFIX%\Scripts\jupyter" serverextension --version > NUL 2>&1 && if errorlevel 1 goto End
-"%PREFIX%\Scripts\jupyter" nbextension --version > NUL 2>&1 && if errorlevel 1 goto End
+"%PREFIX%\Scripts\jupyter-serverextension" --version > NUL 2>&1 && if errorlevel 1 goto End
+"%PREFIX%\Scripts\jupyter-nbextension" --version > NUL 2>&1 && if errorlevel 1 goto End
 
 :: Install the ipyparallel widget.
-"%PREFIX%\Scripts\jupyter" nbextension disable --sys-prefix --py ipyparallel > NUL 2>&1 && if errorlevel 1 exit 1
-"%PREFIX%\Scripts\jupyter" serverextension disable --sys-prefix --py ipyparallel > NUL 2>&1 && if errorlevel 1 exit 1
+"%PREFIX%\Scripts\jupyter-nbextension" disable --sys-prefix --py ipyparallel --Application.log_level=ERROR > NUL && if errorlevel 1 exit 1
+"%PREFIX%\Scripts\jupyter-serverextension" disable --sys-prefix --py ipyparallel --Application.log_level=ERROR > NUL && if errorlevel 1 exit 1
 
 :End
 exit 0

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,7 +1,7 @@
 # Check to make sure we can install the ipyparallel widget.
-("${PREFIX}/bin/jupyter" serverextension --version > /dev/null 2>&1) || exit 0
-("${PREFIX}/bin/jupyter" nbextension --version > /dev/null 2>&1) || exit 0
+("${PREFIX}/bin/jupyter-serverextension" --version > /dev/null 2>&1) || exit 0
+("${PREFIX}/bin/jupyter-nbextension" --version > /dev/null 2>&1) || exit 0
 
 # Install the ipyparallel widget.
-"${PREFIX}/bin/jupyter" nbextension disable --sys-prefix --py ipyparallel > /dev/null 2>&1
-"${PREFIX}/bin/jupyter" serverextension disable --sys-prefix --py ipyparallel > /dev/null 2>&1
+"${PREFIX}/bin/jupyter-nbextension" disable --sys-prefix --py ipyparallel --Application.log_level=ERROR > /dev/null
+"${PREFIX}/bin/jupyter-serverextension" disable --sys-prefix --py ipyparallel --Application.log_level=ERROR > /dev/null


### PR DESCRIPTION
Closes https://github.com/conda-forge/ipyparallel-feedstock/pull/11
- don’t suppress _all_ output, only normal output (should help diagnose when there are real errors)
- use `PREFIX/bin/jupyter-nbextension` rather than `jupyter nbextension`, which can resolve outside the env (possible cause of the failure)

My guess is that the errors people were encountering (#8) had to do with the fact that `jupyter nbextension` can run, even if `jupyter-nbextension` doesn't come from the env (e.g. system-wide install still on PATH), causing unexpected behavior.

I also elected against suppressing error output, but I can send that to .messages (as in #11), if preferred.
