### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ stages:
   jobs:
     - job: Skip
       pool:
-        vmImage: 'ubuntu-22.04'
+        vmImage: 'ubuntu-latest'
       variables:
         DECODE_PERCENTS: 'false'
         RET: 'true'

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,24 +1,22 @@
+# -*- mode: toml -*-
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: toml -*-
+"$schema" = "https://pixi.sh/v0.59.0/schema/manifest/schema.json"
 
-#                             VVVVVV  minimum `pixi` version
-"$schema" = "https://pixi.sh/v0.36.0/schema/manifest/schema.json"
-
-[project]
+[workspace]
 name = "ipyparallel-feedstock"
-version = "3.52.3"  # conda-smithy version used to generate this file
+version = "3.54.2"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/ipyparallel-feedstock"
 authors = ["@conda-forge/ipyparallel"]
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "win-64"]
+requires-pixi = ">=0.59.0"
 
 [dependencies]
 conda-build = ">=24.1"
 conda-forge-ci-setup = "4.*"
 rattler-build = "*"
 
-[tasks]
 [tasks.inspect-all]
 cmd = "inspect_artifacts --all-packages"
 description = "List contents of all packages found in rattler-build build directory."
@@ -34,7 +32,6 @@ description = "List contents of ipyparallel-feedstock packages built for variant
 
 [feature.smithy.dependencies]
 conda-smithy = "*"
-shellcheck = "*"
 [feature.smithy.tasks.build-locally]
 cmd = "python ./build-locally.py"
 description = "Build packages locally using the same setup scripts used in conda-forge's CI"
@@ -50,5 +47,6 @@ description = "Lint the feedstock recipe"
 
 [environments]
 smithy = ["smithy"]
+
 # This is a copy of default, to be enabled by build_steps.sh during Docker builds
 # __PLATFORM_SPECIFIC_ENV__ = []

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,7 +12,7 @@ source:
   sha256: d992edd698a99d45f2d9059af1c9ae8f086d1aeedb3e80436029a2f28d069f83
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script:
     - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
@@ -55,7 +55,7 @@ tests:
   - requirements:
       run:
         - python ${{ python_min }}.*
-        - jupyterlab ==4.*
+        - jupyterlab 4.*
         - nbclassic
     script:
       - ipcluster -h


### PR DESCRIPTION
The `.*` glob pattern is incompatible with `==` and `>=` operators. Use bare glob `X.Y.*` instead of `==X.Y.*`, and `>=X.Y` instead of `>=X.Y.*`.